### PR TITLE
Fix VIM syntax highlight issue on initramfs-init.in.

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -546,8 +546,8 @@ if [ -z "$KOPT_apkovl" ]; then
 elif is_url "$KOPT_apkovl"; then
 	# Fetch apkovl via network
 	MACHINE_UUID=$(cat /sys/class/dmi/id/product_uuid 2>/dev/null)
-	url="${KOPT_apkovl/{MAC\}/$MAC_ADDRESS}"
-	url="${url/{UUID\}/$MACHINE_UUID}"
+	url="${KOPT_apkovl/\{MAC\}/$MAC_ADDRESS}"
+	url="${url/\{UUID\}/$MACHINE_UUID}"
 	ovl=/tmp/${url##*/}
 	wget -O "$ovl" "$url" || ovl=
 else


### PR DESCRIPTION
sh.vim comes with VIM 8 could not identify the matching of following
case.

    > "${KOPT_apkovl/{MAC\}/$MAC_ADDRESS}"

Hence the "color" afterwards is totally messed. Luckily, following
escaping works in busybox.

    > "${KOPT_apkovl/\{MAC\}/$MAC_ADDRESS}"

Thus I made this fix.